### PR TITLE
Adjust years below 100 to either 19xx or 20xx

### DIFF
--- a/src/DateTimePicker/Parser.elm
+++ b/src/DateTimePicker/Parser.elm
@@ -135,7 +135,7 @@ dateParser =
         |. skipOptionalSpaces
         |. Parser.symbol "/"
         |. skipOptionalSpaces
-        |= Parser.int
+        |= Parser.map adjustYear Parser.int
 
 
 {-| Parse the exact format "%I:%M %p"
@@ -166,3 +166,18 @@ dateTimeParser =
         |= dateParser
         |. skipAtLeastOneSpace
         |= timeParser
+
+
+{-| Adjust year values less than 100 to either 19xx or 20xx,
+so for example "19" means "2019".
+-}
+adjustYear : Int -> Int
+adjustYear year =
+    if year < 50 then
+        2000 + year
+
+    else if year < 100 then
+        1900 + year
+
+    else
+        year

--- a/tests/ParserTest.elm
+++ b/tests/ParserTest.elm
@@ -1,4 +1,4 @@
-module ParserTest exposing (invalidDateTest, parseDateTest, parseDateTimeTest, parseTimeTest)
+module ParserTest exposing (invalidDateTest, parseDateBelow100Test, parseDateBelow50Test, parseDateTest, parseDateTimeTest, parseTimeTest)
 
 import DateTimePicker.DateTime as DateTime
 import DateTimePicker.Parser as Parser
@@ -13,6 +13,22 @@ parseDateTest =
         \() ->
             Parser.parseDate "9/7/2018"
                 |> Expect.equal (Just (DateTime.fromParts 2018 Time.Sep 7 0 0))
+
+
+parseDateBelow50Test : Test
+parseDateBelow50Test =
+    test "it parses a date below 50 correctly" <|
+        \() ->
+            Parser.parseDate "9/7/18"
+                |> Expect.equal (Just (DateTime.fromParts 2018 Time.Sep 7 0 0))
+
+
+parseDateBelow100Test : Test
+parseDateBelow100Test =
+    test "it parses a date below 100 correctly" <|
+        \() ->
+            Parser.parseDate "9/7/83"
+                |> Expect.equal (Just (DateTime.fromParts 1983 Time.Sep 7 0 0))
 
 
 parseTimeTest : Test


### PR DESCRIPTION
When a user types a date like "09/03/19" that means "09/03/2019" for a user. However the current datetime picker will consider that "19" as the year 19, not 2019.

This PR changes that so that after typing "09/03/19" it automatically becomes "09/03/2019".

The logic is actually:
- if the year is less than 50, turn it into 20xx
- if the year is less than 100, turn it into 19xx (so typing "81" means "1981")

This behavior and heuristic is inspired by the original datetime picker that this fork is based off, check that it works the same in the demo:

https://abadi199.github.io/datetimepicker/

To be honest, I couldn't find where that logic resides in the original datetime picker. Ideally if we are in the year 2119 then typing "19" should mean "2119", not "2019". But I think we can fix that when the time comes (in more than 30 years).
 