### PR TITLE
Fix layout for elements with semantic names

### DIFF
--- a/src/DateTimePicker.elm
+++ b/src/DateTimePicker.elm
@@ -388,8 +388,11 @@ dialog pickerType state currentDate =
 
 
 dialogNode : List (Html.Attribute msg) -> List (Html msg) -> Html msg
-dialogNode =
+dialogNode attributes =
     Html.node "date-time-picker-dialog"
+        ([ css [ display block ] ]
+            ++ attributes
+        )
 
 
 datePickerDialog : Type msg -> State -> Maybe DateTime.DateTime -> Html msg
@@ -406,6 +409,7 @@ datePickerDialog pickerType state currentDate =
                         [ Styles.headerStyle
                         , Styles.borderBoxStyle
                         , Styles.headerStyle
+                        , display block
                         , position relative
                         ]
                     ]
@@ -414,7 +418,8 @@ datePickerDialog pickerType state currentDate =
                 , -- Footer
                   Html.node "date-time-picker-footer"
                     [ css
-                        [ textAlign center
+                        [ display block
+                        , textAlign center
                         , backgroundColor Styles.lightGray
                         , padding2 (px 7) (px 7)
                         , borderTop3 (px 1) solid Styles.darkGray


### PR DESCRIPTION
This fixes some layout issues that were introduced 7db326c6dcb189427a6f4950aec90ec60f0009f2.

The TLDR is that custom elements are `display: inline` by default, and divs are `display: block`, meaning that we needed to add back the `block` to preserve the original layout.

**Before:**

<img width="284" alt="image" src="https://user-images.githubusercontent.com/2635560/67245123-1c1fa200-f410-11e9-86b1-8a86faff21b6.png">

**After:**

<img width="273" alt="image" src="https://user-images.githubusercontent.com/2635560/67245106-0dd18600-f410-11e9-97ff-908ba2557191.png">